### PR TITLE
fix: escape JSON in single build matrix

### DIFF
--- a/.github/workflows/build-system.yml
+++ b/.github/workflows/build-system.yml
@@ -115,7 +115,7 @@ jobs:
             echo "single_kernel_version=${KERN_VER}" >> $GITHUB_OUTPUT
             echo "single_os_version=${OS_VER}" >> $GITHUB_OUTPUT
             
-            MATRIX="[{"system_type":"$SYS_TYPE","kernel_version":"$KERN_VER","bootstrap_tool":"$TOOL","debian_version":"$DEB_VER","ubuntu_version":"$UBU_VER","desktop_env":"$DESKTOP_ENV"}]"
+            MATRIX="[{\"system_type\":\"$SYS_TYPE\",\"kernel_version\":\"$KERN_VER\",\"bootstrap_tool\":\"$TOOL\",\"debian_version\":\"$DEB_VER\",\"ubuntu_version\":\"$UBU_VER\",\"desktop_env\":\"$DESKTOP_ENV\"}]"
           else
             # 并行模式：使用纯 bash 生成 JSON
             MATRIX="["


### PR DESCRIPTION
Description

Fix invalid JSON generation in single build mode.

Problem

When using single build mode, the workflow constructs the build matrix directly in a Bash string. The JSON quotation marks were not escaped, causing the generated matrix to be invalid JSON.

For example, the generated value could look like:

[{system_type:ubuntu-server,kernel_version:7.1,...}]

This caused fromJSON() to fail when evaluating the build job matrix, resulting in:

Error when evaluating 'strategy' for job 'build'
Fix

Escape the JSON quotation marks in the single mode matrix construction.

This keeps the generated matrix valid JSON while leaving the existing parallel mode logic unchanged.

Verification

Tested the fix with GitHub Actions using:

Build mode: single
System type: ubuntu-gnome
Kernel version: 7.1
Bootstrap tool: mmdebstrap
Ubuntu version: resolute
Desktop environment: phosh-core

The workflow completed successfully:

generate-matrix ✅
build ubuntu-gnome-7.1 ✅
Release ✅

The resulting artifact was:

rootfs-ubuntu-gnome-7.1-resolute